### PR TITLE
One-hot embedding of tabular x-ray diagnosis data

### DIFF
--- a/utils/data_helpers.py
+++ b/utils/data_helpers.py
@@ -1,10 +1,12 @@
 import glob
 from google_drive_downloader import GoogleDriveDownloader as gdd
 import io
+from itertools import repeat
 import math
 from matplotlib import pyplot as plt
 import numpy as np
 import os
+import pandas as pd
 import pathlib
 from random import randint
 import tarfile
@@ -295,5 +297,5 @@ def concat_columns_into_vector(encoded_tabular_df):
     """
     image_embedding_dict = {}
     for _, row in encoded_tabular_df.iterrows():
-        image_embedding_dict[row['Path']] = row[row.columns != 'Path'].values
+        image_embedding_dict[row['Path']] = row[encoded_tabular_df.columns != 'Path'].values
     return image_embedding_dict

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -93,3 +93,9 @@ def format_for_windows(path_string):
 
 def num_tfrecords_in_dir(directory):
     return len([name for name in os.listdir(directory) if os.path.isfile(name) and name.endswith('.tfrecord')])
+
+def normalise(num_list):
+    """ Simple normalisation into [0,1] """
+    max_x = max(num_list)
+    min_x = min(num_list)
+    return [(x - min_x) / (max_x - min_x) for x in num_list]

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -1,5 +1,7 @@
+from itertools import repeat
 import json
 import os
+import pandas as pd
 import pickle
 import tensorflow as tf
 import yaml
@@ -93,3 +95,31 @@ def format_for_windows(path_string):
 
 def num_tfrecords_in_dir(directory):
     return len([name for name in os.listdir(directory) if os.path.isfile(name) and name.endswith('.tfrecord')])
+
+def load_tabular_data(tabular_xray_path='data/CheXpert-v1.0-small/train.csv'):
+    tab_xray_df = pd.read_csv(tabular_xray_path).fillna('nan')
+    return tab_xray_df
+
+def build_encoding_map(column):
+    encoding_map = {}
+    unique_value_list = column.unique().tolist()
+    for idx, unique_value in enumerate(unique_value_list):
+        encoding_map[unique_value] = idx
+    return encoding_map
+
+def encode_tabular_data(tab_xray_df):
+    encoded_df = pd.DataFrame()
+    for column in tab_xray_df:
+        if column != 'Path':
+            encoding_map = build_encoding_map(tab_xray_df[column])
+            if not column in tab_xray_df:
+                print(f'{elem} is not in {encoding_map}')
+            encoded_column =  list(map(
+                lambda elem, encoding_map: encoding_map[elem],
+                tab_xray_df[column],
+                repeat(encoding_map)
+            ))
+            encoded_df[column] = encoded_column
+        else:
+            encoded_df[column] = tab_xray_df[column]
+    return encoded_df

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -95,31 +95,3 @@ def format_for_windows(path_string):
 
 def num_tfrecords_in_dir(directory):
     return len([name for name in os.listdir(directory) if os.path.isfile(name) and name.endswith('.tfrecord')])
-
-def load_tabular_data(tabular_xray_path='data/CheXpert-v1.0-small/train.csv'):
-    tab_xray_df = pd.read_csv(tabular_xray_path).fillna('nan')
-    return tab_xray_df
-
-def build_encoding_map(column):
-    encoding_map = {}
-    unique_value_list = column.unique().tolist()
-    for idx, unique_value in enumerate(unique_value_list):
-        encoding_map[unique_value] = idx
-    return encoding_map
-
-def encode_tabular_data(tab_xray_df):
-    encoded_df = pd.DataFrame()
-    for column in tab_xray_df:
-        if column != 'Path':
-            encoding_map = build_encoding_map(tab_xray_df[column])
-            if not column in tab_xray_df:
-                print(f'{elem} is not in {encoding_map}')
-            encoded_column =  list(map(
-                lambda elem, encoding_map: encoding_map[elem],
-                tab_xray_df[column],
-                repeat(encoding_map)
-            ))
-            encoded_df[column] = encoded_column
-        else:
-            encoded_df[column] = tab_xray_df[column]
-    return encoded_df

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -1,7 +1,5 @@
-from itertools import repeat
 import json
 import os
-import pandas as pd
 import pickle
 import tensorflow as tf
 import yaml


### PR DESCRIPTION
Comments required on two points please:
1. I wasn't really sure where these functions should sit, can you think of anything better than `utils/data_helpers.py`?
at the moment I run then like this:
```
 > from utils.data_helpers import encode_tabular_data, build_encoding_map, load_tabular_data, concat_columns_into_vector
> tab_xray_df = load_tabular_data('data/CheXpert-v1.0-small/train.csv')
> encoded_df = encode_tabular_data(tab_xray_df)
>  embedding_dict = concat_columns_into_vector(encoded_df)
```

2. Can you see any problem with the way that I have gone about assigning different categories to numerical integers? I'm worried that by doing this, I've implicitly made certain categories more related to each other than others. For instance, if I have three categories `['X positive, X negative, no record]`, and I assign these to the categoricals `[0, 1, 2]`. Is building in that `X positive` is less similar to `no record` than `X positive` is to `X negative` an issue? Obviously we will train some embedding on top of this, but maybe the initialization is dangerous? 

Probably don't merge yet @Devin-Taylor 