### PR TITLE
Added batching for TFRecord based datasets

### DIFF
--- a/dataloaders/dataloaders.py
+++ b/dataloaders/dataloaders.py
@@ -11,34 +11,38 @@ def create_dataloaders(args):
     if dataset.type == 'images':
         return image_loaders(dataset, args.batch_size)
     elif dataset.type == 'images-with-captions':
-        return image_with_captions_loaders(dataset)
+        return image_with_captions_loaders(dataset, args.batch_size)
     elif dataset.type == 'images-with-tabular':
-        return image_with_tabular(dataset)
+        return image_with_tabular(dataset, args.batch_size)
     else:
         raise Exception('Unexpected dataset type: {}'.format(dataset.type))
 
-def image_with_tabular(dataset):
+def image_with_tabular(dataset, batch_size):
     """ Read, prepare, and present the TFRecord data for images
         alongside the corresponding tabular data
     """
     train_loader = ImageTextDataLoader(
         dataset_object=dataset,
+        batch_size=batch_size,
         subset='train'
     )
     test_loader = ImageTextDataLoader(
         dataset_object=dataset,
+        batch_size=batch_size,
         subset='valid'
     )
     return train_loader, test_loader, dataset.get_dims()
 
-def image_with_captions_loaders(dataset):
+def image_with_captions_loaders(dataset, batch_size):
     """ Read, prepare, and present the TFRecord data """
     train_loader = ImageTextDataLoader(
         dataset_object=dataset,
+        batch_size=batch_size,
         subset='train'
     )
     test_loader = ImageTextDataLoader(
         dataset_object=dataset,
+        batch_size=batch_size,
         subset='test'
     )
     return train_loader, test_loader, dataset.get_dims()
@@ -73,18 +77,20 @@ def image_loaders(dataset, batch_size):
 
 class ImageTextDataLoader(object):
     """ Define a dataloader for image-text pairs """
-    def __init__(self, dataset_object, subset):
+    def __init__(self, dataset_object, batch_size, subset):
         """ Initialise a ImageTextDataLoader object for either the train
             or test subsets using a BirdsWithWordsDataset object.
         """
         # self.index = 0
         self.subset = subset
+        self.batch_size = batch_size
         self.dataset_object = dataset_object
-        self.parsed_subset = self.dataset_object.parse_dataset(self.subset)
+        self.parsed_subset = self.dataset_object.parse_dataset(self.subset, self.batch_size)
 
     def __call__(self):
         for sample in self.parsed_subset:
             yield sample
 
     def __len__(self):
+        """ TODO: Check that the length is not incorrect because of the addition of batch sizes """
         return num_tfrecords_in_dir(os.path.join(self.dataset_object.directory, self.subset))

--- a/main.py
+++ b/main.py
@@ -101,6 +101,7 @@ def main(args):
         trainer_class = get_trainer(args.dataset_name)
         trainer = trainer_class(
             model=model,
+            batch_size=args.batch_size,
             save_location=results_dir
         )
         trainer(train_loader, num_epochs=args.num_epochs)

--- a/trainers/base_trainer.py
+++ b/trainers/base_trainer.py
@@ -2,18 +2,21 @@ import tensorflow as tf
 
 
 class Trainer(object):
-    def __init__(self, model, save_location,
+    def __init__(self, model, batch_size, save_location,
                  show_progress_bar=True):
         """ Initialise the model trainer
             Arguments:
             model: models.ConditionalGAN
                 The model to train
+            batch_size: int
+                The number of samples per mini-batch
             save_location: str
                 The directory in which to save all
                 results from training the model.
         """
         self.show_progress_bar = show_progress_bar
         self.model = model
+        self.batch_size = batch_size
         self.save_dir = save_location
 
     def __call__(self, data_loader, num_epochs):

--- a/trainers/image_trainer.py
+++ b/trainers/image_trainer.py
@@ -5,17 +5,19 @@ from trainers.base_trainer import Trainer
 
 class ImageTrainer(Trainer):
     """ A image-to-image GAN training class """
-    def __init__(self, model, save_location,
+    def __init__(self, model, batch_size, save_location,
                  show_progress_bar=True):
         """ Initialise a model trainer for iamge data.
             Arguments:
             model: models.ConditionalGAN
                 The model to train
+            batch_size: int
+                The number of samples per mini-batch
             save_location: str
                 The directory in which to save all
                 results from training the model.
         """
-        super().__init__(model, save_location, show_progress_bar)
+        super().__init__(model, batch_size, save_location, show_progress_bar)
 
     def train_epoch(self, train_loader, epoch_num):
         """ Training operations for a single epoch """

--- a/trainers/text_to_image_trainer.py
+++ b/trainers/text_to_image_trainer.py
@@ -7,17 +7,19 @@ from trainers.base_trainer import Trainer
 
 class TextToImageTrainer(Trainer):
     """ Trainer which feeds in text as input to the GAN to generate images """
-    def __init__(self, model, save_location,
+    def __init__(self, model, batch_size, save_location,
                  show_progress_bar=True):
         """ Initialise a model trainer for iamge data.
             Arguments:
             model: models.ConditionalGAN
                 The model to train
+            batch_size: int
+                The number of samples per mini-batch
             save_location: str
                 The directory in which to save all
                 results from training the model.
         """
-        super().__init__(model, save_location, show_progress_bar)
+        super().__init__(model, batch_size, save_location, show_progress_bar)
 
     def train_epoch(self, train_loader, epoch_num):
         """ Training operations for a single epoch """
@@ -29,10 +31,15 @@ class TextToImageTrainer(Trainer):
 
         with trange(len(train_loader), **kwargs) as t:
             for counter, sample in enumerate(train_loader.parsed_subset):
-                image_tensor = np.asarray(Image.open(io.BytesIO(sample['image_raw'].numpy())))
-                print(counter, image_tensor.shape)
+                # For loop simply to demonstrate the number of images in the batch
+                for i in range(self.batch_size):
+                    image_tensor = np.asarray(Image.open(io.BytesIO(sample['image_raw'].numpy()[i])))
+                    print(counter, image_tensor.shape)
+
+                # image_tensor = np.asarray(Image.open(io.BytesIO(sample['image_raw'].numpy())))
+                # print(counter, image_tensor.shape)
                 # For tabular: text_tensor = np.frombuffer(sample['text'].numpy())
                 # For Caption: text_tensor = np.frombuffer(sample['text'].numpy(), dtype=np.float32).reshape(10, 1024)
                 # print(text_tensor)
-                name = sample['name'].numpy().decode("utf-8")
-                label = sample['label'].numpy()
+                # name = sample['name'].numpy().decode("utf-8")
+                # label = sample['label'].numpy()

--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -119,17 +119,16 @@ class BirdsWithWordsDataset(StackedGANDataset):
     # def __len__(self):
     #     return num_tfrecords_in_dir(os.path.join(self.directory, 'train'))
 
-    def parse_dataset(self, subset='train'):
+    def parse_dataset(self, subset='train', batch_size=1):
         """ Parse the raw data from the TFRecords and arrange into a readable form
             for the trainer object.
         """
         if not subset in ['train', 'test']:
             raise Exception('Invalid subset type: {}, expected train or test'.format(subset))
-
         subset_paths = get_record_paths(os.path.join(self.directory, subset))
         subset_obj = tf.data.TFRecordDataset(subset_paths)
         mapped_subset_obj = subset_obj.map(self._parse_example)
-        return mapped_subset_obj
+        return mapped_subset_obj.batch(batch_size)
 
     def _parse_example(self, example_proto):
         # Parse the input tf.Example proto using self.feature_description
@@ -173,7 +172,7 @@ class XRaysDataset(StackedGANDataset):
                 image_dims=(self.height, self.width)
             )
 
-    def parse_dataset(self, subset='train'):
+    def parse_dataset(self, subset='train', batch_size=1):
         """ Parse the raw data from the TFRecords and arrange into a readable form
             for the trainer object.
         """
@@ -183,7 +182,7 @@ class XRaysDataset(StackedGANDataset):
         subset_paths = get_record_paths(os.path.join(self.directory, subset))
         subset_obj = tf.data.TFRecordDataset(subset_paths)
         mapped_subset_obj = subset_obj.map(self._parse_example)
-        return mapped_subset_obj
+        return mapped_subset_obj.batch(batch_size)
 
     def _parse_example(self, example_proto):
         # Parse the input tf.Example proto using self.feature_description


### PR DESCRIPTION
We can now read the data from our TFRecords in batches. Only one thing that may be broken is the `__len__` of the dataset object - I have marked it with a `TODO` to check.